### PR TITLE
create vm using disk

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-// --- Open Targets Genetics Portal Infrastructure      --- //
+/// --- Open Targets Genetics Portal Infrastructure      --- //
 //  Author: Manuel Bernal Llinares <mbdebian@gmail.com> --- //
 
 // --- Provider Configuration --- //
@@ -29,7 +29,6 @@ provider "google-beta" {
 data "google_compute_regions" "gcp_available_regions" {
   project = var.config_project_id
 }
-
 // Availability Zones --- //
 data "google_compute_zones" "gcp_available_zones" {
   count   = length(local.gcp_available_region_names_sorted)
@@ -59,11 +58,14 @@ module "backend_elastic_search" {
   vm_elastic_search_version = var.config_vm_elastic_search_version
   vm_elastic_search_vcpus   = var.config_vm_elastic_search_vcpus
   // Memory size in MiB
-  vm_elastic_search_mem            = var.config_vm_elastic_search_mem
-  vm_elastic_search_image          = var.config_vm_elastic_search_image
-  vm_elastic_search_image_project  = var.config_vm_elastic_search_image_project
-  vm_elastic_search_boot_disk_size = var.config_vm_elastic_search_boot_disk_size
-  vm_flag_preemptible              = var.config_vm_elasticsearch_flag_preemptible
+  vm_elastic_search_mem               = var.config_vm_elastic_search_mem
+  vm_elastic_search_image             = var.config_vm_elastic_search_image
+  vm_elastic_search_image_project     = var.config_vm_elastic_search_image_project
+  vm_elastic_search_boot_disk_size    = var.config_vm_elastic_search_boot_disk_size
+  vm_elastic_search_container_project = var.config_vm_elastic_search_container_project
+  vm_elastic_search_disk_name         = var.config_vm_elastic_search_disk_name
+  vm_elastic_search_disk_project      = var.config_vm_elastic_search_disk_project
+  vm_flag_preemptible                 = var.config_vm_elasticsearch_flag_preemptible
   // Additional firewall tags if development mode is 'ON'
   vm_firewall_tags       = local.dev_fw_tags
   deployment_region      = var.config_deployment_regions[count.index]

--- a/main.tf
+++ b/main.tf
@@ -84,12 +84,15 @@ module "backend_clickhouse" {
   network_source_ranges = [
     local.vpc_network_region_subnet_map[var.config_deployment_regions[count.index]].subnet_ip
   ]
-  vm_clickhouse_vcpus          = var.config_vm_clickhouse_vcpus
-  vm_clickhouse_mem            = var.config_vm_clickhouse_mem
-  vm_clickhouse_image          = var.config_vm_clickhouse_image
-  vm_clickhouse_image_project  = var.config_vm_clickhouse_image_project
-  vm_clickhouse_boot_disk_size = var.config_vm_clickhouse_boot_disk_size
-  vm_flag_preemptible          = var.config_vm_clickhouse_flag_preemptible
+  vm_clickhouse_vcpus             = var.config_vm_clickhouse_vcpus
+  vm_clickhouse_mem               = var.config_vm_clickhouse_mem
+  vm_clickhouse_image             = var.config_vm_clickhouse_image
+  vm_clickhouse_image_project     = var.config_vm_clickhouse_image_project
+  vm_clickhouse_container_project = var.config_vm_clickhouse_container_project
+  vm_clickhouse_disk_project      = var.config_vm_clickhouse_disk_project
+  vm_clickhouse_disk_name         = var.config_vm_clickhouse_disk_name
+  vm_clickhouse_boot_disk_size    = var.config_vm_clickhouse_boot_disk_size
+  vm_flag_preemptible             = var.config_vm_clickhouse_flag_preemptible
   // Additional firewall tags if development mode is 'ON'
   vm_firewall_tags       = local.dev_fw_tags
   deployment_region      = var.config_deployment_regions[count.index]
@@ -127,7 +130,7 @@ module "backend_api" {
   vm_api_image          = var.config_vm_api_image
   vm_api_image_project  = var.config_vm_api_image_project
   vm_api_boot_disk_size = var.config_vm_api_boot_disk_size
-  vm_flag_preemptible           = var.config_vm_api_flag_preemptible
+  vm_flag_preemptible   = var.config_vm_api_flag_preemptible
   backend_connection_map = zipmap(
     var.config_deployment_regions,
     [

--- a/modules/api/compute.tf
+++ b/modules/api/compute.tf
@@ -5,80 +5,80 @@
 //      - a source of entropy per deployment region
 //      - a rendered version of the startup script per region
 resource "random_string" "random_source_api" {
-  length = 8
-  lower = true
-  upper = false
+  length  = 8
+  lower   = true
+  upper   = false
   special = false
   keepers = {
-    api_template_tags = join("", sort(local.api_template_tags)),
+    api_template_tags         = join("", sort(local.api_template_tags)),
     api_template_machine_type = local.api_template_machine_type,
     api_template_source_image = local.api_template_source_image,
-    vm_api_image_version = var.vm_api_image_version,
-    data_backend_details = md5(jsonencode(var.backend_connection_map)),
-    vm_flag_preemptible = var.vm_flag_preemptible
+    vm_api_image_version      = var.vm_api_image_version,
+    data_backend_details      = md5(jsonencode(var.backend_connection_map)),
+    vm_flag_preemptible       = var.vm_flag_preemptible
   }
 }
 
 // Access to Available compute zones in the given regions --- //
 data "google_compute_zones" "gcp_zones_availability" {
   count = length(var.deployment_regions)
-  
+
   project = var.project_id
-  region = var.deployment_regions[count.index]
+  region  = var.deployment_regions[count.index]
 }
 
 // --- Service Account Configuration ---
 resource "google_service_account" "gcp_service_acc_apis" {
-    project = var.project_id
-  account_id = "${var.module_wide_prefix_scope}-svcacc"//-${random_string.random_source_api.result}"
+  project      = var.project_id
+  account_id   = "${var.module_wide_prefix_scope}-svcacc" //-${random_string.random_source_api.result}"
   display_name = "${var.module_wide_prefix_scope}-GCP-service-account"
 }
 
 // Roles ---
 resource "google_project_iam_member" "logging-writer" {
   project = var.project_id
-  role = "roles/logging.logWriter"
-  member = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
 }
 resource "google_project_iam_member" "monitoring-writer" {
   project = var.project_id
-  role = "roles/monitoring.metricWriter"
-  member = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
 }
 // --- /Service Account Configuration/ ---
 
 resource "google_compute_instance_template" "api_vm_template" {
   count = length(var.deployment_regions)
 
-project = var.project_id
-  name = "${var.module_wide_prefix_scope}-api-template-${substr(md5(var.deployment_regions[count.index]), -8, -1)}-${random_string.random_source_api.result}"
-  description = "Open Targets Genetics Portal API node template, API docker image version ${var.vm_api_image_version}"
+  project              = var.project_id
+  name                 = "${var.module_wide_prefix_scope}-api-template-${substr(md5(var.deployment_regions[count.index]), -8, -1)}-${random_string.random_source_api.result}"
+  description          = "Open Targets Genetics Portal API node template, API docker image version ${var.vm_api_image_version}"
   instance_description = "Open Targets Genetics Portal API node, API docker image version ${var.vm_api_image_version}"
-  region = var.deployment_regions[count.index]
-  
-  
+  region               = var.deployment_regions[count.index]
+
+
   tags = local.api_template_tags
 
-  machine_type = local.api_template_machine_type
+  machine_type   = local.api_template_machine_type
   can_ip_forward = false
 
   scheduling {
-    automatic_restart = !var.vm_flag_preemptible
+    automatic_restart   = !var.vm_flag_preemptible
     on_host_maintenance = var.vm_flag_preemptible ? "TERMINATE" : "MIGRATE"
-    preemptible = var.vm_flag_preemptible
+    preemptible         = var.vm_flag_preemptible
     //provisioning_model = "SPOT"
   }
 
   disk {
     source_image = local.api_template_source_image
-    auto_delete = true
-    disk_type = "pd-ssd"
-    boot = true
-    mode = "READ_WRITE"
+    auto_delete  = true
+    disk_type    = "pd-ssd"
+    boot         = true
+    mode         = "READ_WRITE"
   }
 
   network_interface {
-    network = var.network_name
+    network    = var.network_name
     subnetwork = var.network_subnet_name
   }
 
@@ -91,27 +91,27 @@ project = var.project_id
       "${path.module}/scripts/instance_startup.sh",
       {
         SLICK_CLICKHOUSE_URL = "jdbc:clickhouse://${var.backend_connection_map[var.deployment_regions[count.index]].host_clickhouse}:8123/ot",
-        ELASTICSEARCH_HOST = var.backend_connection_map[var.deployment_regions[count.index]].host_elastic_search,
-        API_VERSION = var.vm_api_image_version,
-        API_PORT = local.api_port
+        ELASTICSEARCH_HOST   = var.backend_connection_map[var.deployment_regions[count.index]].host_elastic_search,
+        API_VERSION          = var.vm_api_image_version,
+        API_PORT             = local.api_port
       }
     )
     google-logging-enabled = true
   }
 
   service_account {
-    email = google_service_account.gcp_service_acc_apis.email
-    scopes = [ "cloud-platform", "logging-write", "monitoring-write" ]
+    email  = google_service_account.gcp_service_acc_apis.email
+    scopes = ["cloud-platform", "logging-write", "monitoring-write"]
   }
 }
 
 // --- Health Check definition --- //
 resource "google_compute_health_check" "api_healthcheck" {
-    project = var.project_id
-  name = "${var.module_wide_prefix_scope}-api-healthcheck"
-  check_interval_sec = 5
-  timeout_sec = 5
-  healthy_threshold = 2
+  project             = var.project_id
+  name                = "${var.module_wide_prefix_scope}-api-healthcheck"
+  check_interval_sec  = 5
+  timeout_sec         = 5
+  healthy_threshold   = 2
   unhealthy_threshold = 10
 
   tcp_health_check {
@@ -123,14 +123,14 @@ resource "google_compute_health_check" "api_healthcheck" {
 resource "google_compute_region_instance_group_manager" "regmig_api" {
   count = length(var.deployment_regions)
 
-project = var.project_id
-  name = "${var.module_wide_prefix_scope}-regmig-api-${substr(md5(var.deployment_regions[count.index]), -18, -1)}"
-  region = var.deployment_regions[count.index]
+  project            = var.project_id
+  name               = "${var.module_wide_prefix_scope}-regmig-api-${substr(md5(var.deployment_regions[count.index]), -18, -1)}"
+  region             = var.deployment_regions[count.index]
   base_instance_name = "${var.module_wide_prefix_scope}-${count.index}-api"
-  depends_on = [ 
-      google_compute_instance_template.api_vm_template,
-      module.firewall_rules
-    ]
+  depends_on = [
+    google_compute_instance_template.api_vm_template,
+    module.firewall_rules
+  ]
 
   // Instance Template
   version {
@@ -145,7 +145,7 @@ project = var.project_id
   }
 
   auto_healing_policies {
-    health_check = google_compute_health_check.api_healthcheck.id
+    health_check      = google_compute_health_check.api_healthcheck.id
     initial_delay_sec = 30
   }
 
@@ -163,14 +163,14 @@ project = var.project_id
 resource "google_compute_region_autoscaler" "autoscaler_api" {
   count = length(var.deployment_regions)
 
-project = var.project_id
-  name = "${var.module_wide_prefix_scope}-autoscaler-${substr(md5(var.deployment_regions[count.index]), -18, -1)}"
-  region = var.deployment_regions[count.index]
-  target = google_compute_region_instance_group_manager.regmig_api[count.index].id
+  project = var.project_id
+  name    = "${var.module_wide_prefix_scope}-autoscaler-${substr(md5(var.deployment_regions[count.index]), -18, -1)}"
+  region  = var.deployment_regions[count.index]
+  target  = google_compute_region_instance_group_manager.regmig_api[count.index].id
 
   autoscaling_policy {
-    max_replicas = length(data.google_compute_zones.gcp_zones_availability[count.index].names) * 2
-    min_replicas = 1
+    max_replicas    = length(data.google_compute_zones.gcp_zones_availability[count.index].names) * 2
+    min_replicas    = 1
     cooldown_period = 60
     load_balancing_utilization {
       target = 0.6

--- a/modules/clickhouse/compute.tf
+++ b/modules/clickhouse/compute.tf
@@ -14,6 +14,7 @@ resource "random_string" "random_ch_vm" {
     clickhouse_template_machine_type = local.clickhouse_template_machine_type,
     clickhouse_template_source_image = local.clickhouse_template_source_image,
     clickhouse_disk                  = local.clickhouse_disk,
+    clickhouse_disk_name             = var.vm_clickhouse_disk_name,
     vm_flag_preemptible              = var.vm_flag_preemptible,
     vm_startup_script                = md5(file("${path.module}/scripts/instance_startup.sh"))
   }
@@ -88,7 +89,7 @@ resource "google_compute_instance_template" "clickhouse_template" {
       "${path.module}/scripts/instance_startup.sh",
       {
         CLICKHOUSE_VERSION   = var.vm_clickhouse_version
-        CLICKHOUSE_DEVICE_ID = local.disk_device_name
+        CLICKHOUSE_DEVICE_ID = var.vm_clickhouse_disk_name
       }
     )
     google-logging-enabled = true

--- a/modules/clickhouse/compute.tf
+++ b/modules/clickhouse/compute.tf
@@ -80,9 +80,8 @@ resource "google_compute_instance_template" "clickhouse_template" {
   }
 
   disk {
-    source = google_compute_disk.clickhouse_disk.self_link
-    // mounted under /dev/disk/by-id/google-clickhouse-disk
-    device_name = "${var.vm_clickhouse_image_project}/${var.vm_clickhouse_disk_name}"
+    source      = google_compute_disk.clickhouse_disk.self_link
+    device_name = local.disk_device_name
     disk_type   = local.disk_type
     mode        = local.disk_mode
   }
@@ -101,7 +100,7 @@ resource "google_compute_instance_template" "clickhouse_template" {
       "${path.module}/scripts/instance_startup.sh",
       {
         CLICKHOUSE_VERSION   = var.vm_clickhouse_version
-        CLICKHOUSE_DEVICE_ID = var.vm_clickhouse_disk_name
+        CLICKHOUSE_DEVICE_ID = local.disk_device_name
       }
     )
     google-logging-enabled = true

--- a/modules/clickhouse/compute.tf
+++ b/modules/clickhouse/compute.tf
@@ -42,7 +42,7 @@ resource "google_project_iam_member" "monitoring-writer" {
 resource "google_compute_disk" "clickhouse_disk" {
   name     = var.vm_clickhouse_disk_name
   project  = var.project_id
-  snapshot = "${var.vm_clickhouse_disk_name}-${random_string.random_ch_vm.result}"
+  snapshot = "https://www.googleapis.com/compute/v1/projects/${var.vm_clickhouse_disk_project}/global/snapshots/${var.clickhouse_disk_name}"
   type     = local.disk_type
   size     = local.disk_size
   labels = {
@@ -84,6 +84,7 @@ resource "google_compute_instance_template" "clickhouse_template" {
     device_name = local.disk_device_name
     disk_type   = local.disk_type
     mode        = local.disk_mode
+    zone        = var.deployment_region
   }
 
   network_interface {

--- a/modules/clickhouse/locals.tf
+++ b/modules/clickhouse/locals.tf
@@ -1,18 +1,23 @@
 // --- Helper Information --- //
 locals {
-    // Ports
-    clickhouse_http_req_port = 8123
-    clickhouse_cli_req_port = 9000
-    clickhouse_http_req_port_name  = "portclickhousehttp"
-    clickhouse_cli_req_port_name = "portclickhousereq"
-    // Firewall tags
-    fw_tag_clickhouse_node = "clickhousenode"
 
-    // Clickhouse instance template values
-    clickhouse_template_tags = concat(var.vm_firewall_tags, [ local.fw_tag_clickhouse_node ])
-    clickhouse_template_machine_type = "custom-${var.vm_clickhouse_vcpus}-${var.vm_clickhouse_mem}"
-    clickhouse_template_source_image = "${var.vm_clickhouse_image_project}/${var.vm_clickhouse_image}"
+  // Disk
+  disk_type = "pd-ssd"
+  disk_mode = "READ_WRITE"
+  disk_size = 250
+  // Ports
+  clickhouse_http_req_port      = 8123
+  clickhouse_cli_req_port       = 9000
+  clickhouse_http_req_port_name = "portclickhousehttp"
+  clickhouse_cli_req_port_name  = "portclickhousereq"
+  // Firewall tags
+  fw_tag_clickhouse_node = "clickhousenode"
 
-    // Compute Zones internal parameters
-    compute_zones_n_total = length(data.google_compute_zones.gcp_available_zones.names)
+  // Clickhouse instance template values
+  clickhouse_template_tags         = concat(var.vm_firewall_tags, [local.fw_tag_clickhouse_node])
+  clickhouse_template_machine_type = "custom-${var.vm_clickhouse_vcpus}-${var.vm_clickhouse_mem}"
+  clickhouse_template_source_image = "${var.vm_clickhouse_container_project}/${var.vm_clickhouse_image}"
+
+  // Compute Zones internal parameters
+  compute_zones_n_total = length(data.google_compute_zones.gcp_available_zones.names)
 }

--- a/modules/clickhouse/locals.tf
+++ b/modules/clickhouse/locals.tf
@@ -2,9 +2,10 @@
 locals {
 
   // Disk
-  disk_type = "pd-ssd"
-  disk_mode = "READ_WRITE"
-  disk_size = 250
+  clickhouse_disk = "${var.project_id}/${var.vm_clickhouse_disk_name}"
+  disk_type       = "pd-ssd"
+  disk_mode       = "READ_WRITE"
+  disk_size       = 250
   // Used when mounted into COS container under /mnt/disks/by-id/<device_name>
   disk_device_name = "ch"
   // Ports

--- a/modules/clickhouse/locals.tf
+++ b/modules/clickhouse/locals.tf
@@ -5,6 +5,8 @@ locals {
   disk_type = "pd-ssd"
   disk_mode = "READ_WRITE"
   disk_size = 250
+  // Used when mounted into COS container under /mnt/disks/by-id/<device_name>
+  disk_device_name = "ch"
   // Ports
   clickhouse_http_req_port      = 8123
   clickhouse_cli_req_port       = 9000

--- a/modules/clickhouse/scripts/instance_startup.sh
+++ b/modules/clickhouse/scripts/instance_startup.sh
@@ -1,2 +1,24 @@
 #!/bin/bash
-# This is a placeholder startup script, as it is currently not needed by Clickhouse
+
+echo "[LAUNCH] Open Targets Genetics Portal Clickhouse DB"
+
+echo "Prepare CH disk mount"
+ch_mount="/mnt/disks/ch"
+ch_serv="$ch_mount/var/lib/clickhouse"
+ch_conf="$ch_mount/etc/clickhouse-server/config.d"
+ch_user="$ch_mount/etc/clickhouse-server/user.d"
+
+sudo mount -o discard,defaults /dev/disk/by-id/google-${CLICKHOUSE_DEVICE_ID} $ch_mount
+echo "Mount status exit code: $?"
+# start Clickhouse
+# https://hub.docker.com/r/clickhouse/clickhouse-server/
+echo "---> Starting Clickhouse Docker image"
+docker run -d \
+    -p 8123:8123 \
+    -p 9000:9000 \
+    --name clickhouse \
+    --mount type=bind,source=$ch_serv,target=/var/lib/clickhouse \
+    --mount type=bind,source=$ch_conf,target=/etc/clickhouse-server/config.d \
+    --mount type=bind,source=$ch_user,target=/etc/clickhouse-server/user.d \
+    --ulimit nofile=262144:262144 \
+    clickhouse/clickhouse-server:${CLICKHOUSE_VERSION}

--- a/modules/clickhouse/scripts/instance_startup.sh
+++ b/modules/clickhouse/scripts/instance_startup.sh
@@ -3,7 +3,7 @@
 echo "[LAUNCH] Open Targets Genetics Portal Clickhouse DB"
 
 echo "Prepare CH disk mount"
-ch_mount="/mnt/disks/ch"
+ch_mount="/mnt/disks"
 ch_serv="$ch_mount/var/lib/clickhouse"
 ch_conf="$ch_mount/etc/clickhouse-server/config.d"
 ch_user="$ch_mount/etc/clickhouse-server/user.d"

--- a/modules/clickhouse/variables.tf
+++ b/modules/clickhouse/variables.tf
@@ -70,6 +70,7 @@ variable "vm_clickhouse_mem" {
 variable "vm_clickhouse_image" {
   description = "VM image to use for Clickhouse nodes"
   type        = string
+  default     = "cos-stable"
 }
 
 variable "vm_clickhouse_version" {
@@ -89,11 +90,12 @@ variable "vm_clickhouse_boot_disk_size" {
   default     = "250GB"
 }
 variable "vm_clickhouse_container_project" {
-  description = "Clickhouse disk snapshot created by GOS"
+  description = "Project hosting container optimised images"
   type        = string
+  default     = "cos-cloud"
 }
 variable "vm_clickhouse_disk_project" {
-  description = "Clickhouse disk snapshot created by GOS"
+  description = "Project hosting snapshot created by GOS"
   type        = string
 }
 variable "vm_clickhouse_disk_name" {

--- a/modules/clickhouse/variables.tf
+++ b/modules/clickhouse/variables.tf
@@ -2,37 +2,37 @@
 // General deployment input parameters --- //
 variable "module_wide_prefix_scope" {
   description = "The prefix provided here will scope names for those resources created by this module, default 'mbdevgenesch'"
-  type = string
-  default = "mbdevgenesch"
+  type        = string
+  default     = "mbdevgenesch"
 }
 
 variable "project_id" {
   description = "Project ID where resources will be deployed"
-  type = string
+  type        = string
 }
 
 variable "network_name" {
   description = "Name of the network resources will be connected to, default 'default'"
-  type = string
-  default = "default"
+  type        = string
+  default     = "default"
 }
 
 variable "network_self_link" {
   description = "Self link to the network where resources should be connected when deployed, default 'default'"
-  type = string
-  default = "default"
+  type        = string
+  default     = "default"
 }
 
 variable "network_subnet_name" {
   description = "Name of the subnet, within the 'network_name', and the given region, where instances should be connected to, default 'main-subnet'"
-  type = string
-  default = "main-subnet"
+  type        = string
+  default     = "main-subnet"
 }
 
 variable "network_source_ranges" {
   description = "CIDR that represents which IPs we want to grant access to the deployed resources, default '10.0.0.0/9'"
-  type = list(string)
-  default = [ "10.0.0.0/9" ]
+  type        = list(string)
+  default     = ["10.0.0.0/9"]
 }
 
 variable "network_sources_health_checks" {
@@ -45,52 +45,70 @@ variable "network_sources_health_checks" {
 
 variable "deployment_region" {
   description = "Region where resources should be deployed"
-  type = string
+  type        = string
 }
 
 // --- Clickhouse Instance Configuration --- //
 variable "vm_firewall_tags" {
   description = "Additional tags to attach to deployed Clickhouse nodes, by default, no additional tags will be attached"
-  type = list(string)
-  default = [ ]
+  type        = list(string)
+  default     = []
 }
 
 variable "vm_clickhouse_vcpus" {
   description = "CPU count for Clickhouse instances, default '4'"
-  type = number
-  default = "4"
+  type        = number
+  default     = "4"
 }
 
 variable "vm_clickhouse_mem" {
   description = "Amount of memory allocated for Clickhouse instances (MiB), default '26624'"
-  type = number
-  default = "26624"
+  type        = number
+  default     = "26624"
 }
 
 variable "vm_clickhouse_image" {
   description = "VM image to use for Clickhouse nodes"
-  type = string
+  type        = string
+}
+
+variable "vm_clickhouse_version" {
+  description = "Clickhouse Docker Image version to use"
+  type        = string
+  default     = "22.3.12.19-alpine"
 }
 
 variable "vm_clickhouse_image_project" {
   description = "Project hosting Clickhouse VM image"
-  type = string
+  type        = string
 }
 
 variable "vm_clickhouse_boot_disk_size" {
   description = "Clickhouse VM boot disk size, default '250GB'"
-  type = string
-  default = "250GB"
+  type        = string
+  default     = "250GB"
+}
+variable "vm_clickhouse_container_project" {
+  description = "Clickhouse disk snapshot created by GOS"
+  type        = string
+}
+variable "vm_clickhouse_disk_project" {
+  description = "Clickhouse disk snapshot created by GOS"
+  type        = string
+}
+variable "vm_clickhouse_disk_name" {
+  description = "Clickhouse disk snapshot created by GOS"
+  type        = string
 }
 
 variable "vm_flag_preemptible" {
   description = "Use this flag to tell the module to use a preemptible instance, default: 'false'"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "deployment_target_size" {
   description = "This number configures how many instances should be running, default '1'"
-  type = number
-  default = 1
+  type        = number
+  default     = 1
 }

--- a/modules/elasticsearch/compute.tf
+++ b/modules/elasticsearch/compute.tf
@@ -1,70 +1,89 @@
 // --- Elastic Search Nodes definition --- //
 // Entropy source for Elascticsearch nodes definition
 resource "random_string" "random_es_vm" {
-  length = 8
-  lower = true
-  upper = false
+  length  = 8
+  lower   = true
+  upper   = false
   special = false
   keepers = {
     elastic_search_template_machine_type = local.elastic_search_template_machine_type,
     elastic_search_template_source_image = local.elastic_search_template_source_image,
-    elastic_search_template_tags = join("", sort(local.elastic_search_template_tags)),
-    vm_elastic_search_version = var.vm_elastic_search_version
-    vm_startup_script = md5(file("${path.module}/scripts/instance_startup.sh"))
-    vm_flag_preemptible = var.vm_flag_preemptible
+    elastic_search_template_tags         = join("", sort(local.elastic_search_template_tags)),
+    vm_elastic_search_version            = var.vm_elastic_search_version
+    vm_startup_script                    = md5(file("${path.module}/scripts/instance_startup.sh"))
+    vm_flag_preemptible                  = var.vm_flag_preemptible
   }
 }
 
 // --- Service Account Configuration ---
 resource "google_service_account" "gcp_service_acc_apis" {
-    project = var.project_id
-  account_id = "${var.module_wide_prefix_scope}-svc"//-${random_string.random_es_vm.result}"
+  project      = var.project_id
+  account_id   = "${var.module_wide_prefix_scope}-svc" //-${random_string.random_es_vm.result}"
   display_name = "${var.module_wide_prefix_scope}-GCP-service-account"
 }
 
 // Roles ---
 resource "google_project_iam_member" "logging-writer" {
   project = var.project_id
-  role = "roles/logging.logWriter"
-  member = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
 }
 resource "google_project_iam_member" "monitoring-writer" {
   project = var.project_id
-  role = "roles/monitoring.metricWriter"
-  member = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gcp_service_acc_apis.email}"
 }
 // --- /Service Account Configuration/ ---
 
+// --- /Disk configuration/ ---
+resource "google_compute_disk" "es_disk" {
+  name     = var.vm_elastic_search_disk_name
+  project  = var.project_id
+  snapshot = "${var.vm_elastic_search_disk_name}-${random_string.random_es_vm.result}"
+  type     = local.disk_type
+  size     = local.disk_size
+  labels = {
+    datatype = "elasticsearch"
+  }
+  description = "Precomputed data for Elasticsearch. The disk needs to be mounted and two directories should be exposed to a docker container: `<mnt>/etc/clickhouse-server/config.d` and `<mnt>/etc/clickhouse-server/user.d`"
+}
 // Elastic Search instance template definition --- //
 resource "google_compute_instance_template" "elastic_search_template" {
-    project = var.project_id
-  name = "${var.module_wide_prefix_scope}-elastic-search-template-${random_string.random_es_vm.result}"
-  description = "Open Targets Genetics Portal Elastic Search node template, release ${var.vm_elastic_search_image}"
+  project              = var.project_id
+  name                 = "${var.module_wide_prefix_scope}-elastic-search-template-${random_string.random_es_vm.result}"
+  description          = "Open Targets Genetics Portal Elastic Search node template, release ${var.vm_elastic_search_image}"
   instance_description = "Open Targets Genetics Portal Elastic Search node - release ${var.vm_elastic_search_image}"
-  region = var.deployment_region
-    
+  region               = var.deployment_region
+
   tags = local.elastic_search_template_tags
 
-  machine_type = local.elastic_search_template_machine_type
+  machine_type   = local.elastic_search_template_machine_type
   can_ip_forward = false
 
   scheduling {
-    automatic_restart = !var.vm_flag_preemptible
+    automatic_restart   = !var.vm_flag_preemptible
     on_host_maintenance = var.vm_flag_preemptible ? "TERMINATE" : "MIGRATE"
-    preemptible = var.vm_flag_preemptible
+    preemptible         = var.vm_flag_preemptible
     //provisioning_model = "SPOT"
   }
 
   disk {
     source_image = local.elastic_search_template_source_image
-    auto_delete = true
-    disk_type = "pd-ssd"
-    boot = true
-    mode = "READ_WRITE"
+    auto_delete  = true
+    disk_type    = "pd-ssd"
+    boot         = true
+    mode         = "READ_WRITE"
   }
 
+  disk {
+    source = google_compute_disk.es_disk.self_link
+    // mounted under /dev/disk/by-id/google-clickhouse-disk
+    device_name = var.vm_elastic_search_disk_name
+    disk_type   = local.disk_type
+    mode        = local.disk_mode
+  }
   network_interface {
-    network = var.network_name
+    network    = var.network_name
     subnetwork = var.network_subnet_name
   }
 
@@ -76,6 +95,7 @@ resource "google_compute_instance_template" "elastic_search_template" {
     startup-script = templatefile(
       "${path.module}/scripts/instance_startup.sh",
       {
+        ES_DEVICE_ID           = local.disk_mount_name
         ELASTIC_SEARCH_VERSION = var.vm_elastic_search_version
       }
     )
@@ -83,19 +103,19 @@ resource "google_compute_instance_template" "elastic_search_template" {
   }
 
   service_account {
-      // TODO - Do I really need a service account for logging?
-    email = google_service_account.gcp_service_acc_apis.email
-    scopes = [ "cloud-platform", "logging-write", "monitoring-write" ]
+    // TODO - Do I really need a service account for logging?
+    email  = google_service_account.gcp_service_acc_apis.email
+    scopes = ["cloud-platform", "logging-write", "monitoring-write"]
   }
 }
 
 // Elastic Search Health Check for instance group --- //
 resource "google_compute_health_check" "elastic_search_healthcheck" {
-    project = var.project_id
-  name = "${var.module_wide_prefix_scope}-elastic-search-healthcheck"
-  check_interval_sec = 5
-  timeout_sec = 5
-  healthy_threshold = 2
+  project             = var.project_id
+  name                = "${var.module_wide_prefix_scope}-elastic-search-healthcheck"
+  check_interval_sec  = 5
+  timeout_sec         = 5
+  healthy_threshold   = 2
   unhealthy_threshold = 10
 
   tcp_health_check {
@@ -106,16 +126,14 @@ resource "google_compute_health_check" "elastic_search_healthcheck" {
 
 // Elastic Search Regional Instance Group Manager --- //
 resource "google_compute_region_instance_group_manager" "regmig_elastic_search" {
-    project = var.project_id
-  name = "${var.module_wide_prefix_scope}-regmig-elastic-search"
-  region = var.deployment_region
+  project            = var.project_id
+  name               = "${var.module_wide_prefix_scope}-regmig-elastic-search"
+  region             = var.deployment_region
   base_instance_name = "${var.module_wide_prefix_scope}-esearch"
-  depends_on = [ 
-      google_compute_instance_template.elastic_search_template,
-      //google_compute_firewall.vpc_netfw_elasticsearch_requests,
-      //google_compute_firewall.vpc_netfw_elasticsearch_comms
-      module.firewall_rules
-    ]
+  depends_on = [
+    google_compute_instance_template.elastic_search_template,
+    module.firewall_rules
+  ]
 
   // Instance Template
   version {
@@ -135,7 +153,7 @@ resource "google_compute_region_instance_group_manager" "regmig_elastic_search" 
   }
 
   auto_healing_policies {
-    health_check = google_compute_health_check.elastic_search_healthcheck.id
+    health_check      = google_compute_health_check.elastic_search_healthcheck.id
     initial_delay_sec = 300
   }
 
@@ -151,14 +169,14 @@ resource "google_compute_region_instance_group_manager" "regmig_elastic_search" 
 
 // Elastic Search autoscaling definition --- //
 resource "google_compute_region_autoscaler" "autoscaler_elastic_search" {
-    project = var.project_id
-  name = "${var.module_wide_prefix_scope}-autoscaler"
-  region = var.deployment_region
-  target = google_compute_region_instance_group_manager.regmig_elastic_search.id
+  project = var.project_id
+  name    = "${var.module_wide_prefix_scope}-autoscaler"
+  region  = var.deployment_region
+  target  = google_compute_region_instance_group_manager.regmig_elastic_search.id
 
   autoscaling_policy {
-    max_replicas = local.compute_zones_n_total * 2
-    min_replicas = 1
+    max_replicas    = local.compute_zones_n_total * 2
+    min_replicas    = 1
     cooldown_period = 60
     cpu_utilization {
       target = 0.75

--- a/modules/elasticsearch/compute.tf
+++ b/modules/elasticsearch/compute.tf
@@ -8,6 +8,7 @@ resource "random_string" "random_es_vm" {
   keepers = {
     elastic_search_template_machine_type = local.elastic_search_template_machine_type,
     elastic_search_template_source_image = local.elastic_search_template_source_image,
+    elastic_search_disk_name             = var.vm_elastic_search_disk_name,
     elastic_search_disk                  = local.elastic_search_disk,
     elastic_search_template_tags         = join("", sort(local.elastic_search_template_tags)),
     vm_elastic_search_version            = var.vm_elastic_search_version
@@ -84,7 +85,7 @@ resource "google_compute_instance_template" "elastic_search_template" {
     startup-script = templatefile(
       "${path.module}/scripts/instance_startup.sh",
       {
-        ES_DEVICE_ID           = local.disk_mount_name
+        ES_DEVICE_ID           = var.vm_elastic_search_disk_name
         ELASTIC_SEARCH_VERSION = var.vm_elastic_search_version
       }
     )

--- a/modules/elasticsearch/compute.tf
+++ b/modules/elasticsearch/compute.tf
@@ -39,8 +39,8 @@ resource "google_project_iam_member" "monitoring-writer" {
 resource "google_compute_disk" "es_disk" {
   name     = var.vm_elastic_search_disk_name
   project  = var.project_id
-  snapshot = "${var.vm_elastic_search_disk_name}-${random_string.random_es_vm.result}"
   type     = local.disk_type
+  snapshot = "https://www.googleapis.com/compute/v1/projects/${var.vm_elastic_search_disk_project}/global/snapshots/${var.vm_elastic_search_disk_name}"
   size     = local.disk_size
   labels = {
     datatype = "elasticsearch"
@@ -81,6 +81,7 @@ resource "google_compute_instance_template" "elastic_search_template" {
     device_name = var.vm_elastic_search_disk_name
     disk_type   = local.disk_type
     mode        = local.disk_mode
+    zone        = var.deployment_region
   }
   network_interface {
     network    = var.network_name

--- a/modules/elasticsearch/locals.tf
+++ b/modules/elasticsearch/locals.tf
@@ -1,13 +1,20 @@
 // Helper information
 locals {
+
+  // Disk
+  disk_type = "pd-ssd"
+  disk_mode = "READ_WRITE"
+  disk_size = 50
+  // name used to find disk in running image
+  disk_mount_name = "es-disk"
   // Ports
-  elastic_search_port_requests  = 9200
-  elastic_search_port_comms     = 9300
+  elastic_search_port_requests      = 9200
+  elastic_search_port_comms         = 9300
   elastic_search_port_requests_name = "esportrequests"
-  elastic_search_port_comms_name = "esportcomms"
+  elastic_search_port_comms_name    = "esportcomms"
   // Firewall tags
   fw_tag_elasticsearch_requests = "elasticsearchrequests"
-  fw_tag_elasticsearch_comms = "elasticsearchcomms"
+  fw_tag_elasticsearch_comms    = "elasticsearchcomms"
 
   // Elastic Search instance template values
   elastic_search_template_tags = concat(
@@ -18,7 +25,7 @@ locals {
     ]
   )
   elastic_search_template_machine_type = "custom-${var.vm_elastic_search_vcpus}-${var.vm_elastic_search_mem}"
-  elastic_search_template_source_image = "${var.vm_elastic_search_image_project}/${var.vm_elastic_search_image}"
+  elastic_search_template_source_image = "${var.vm_elastic_search_container_project}/${var.vm_elastic_search_image}"
   // Compute Zones internal parameters
   compute_zones_n_total = length(data.google_compute_zones.gcp_available_zones.names)
 }

--- a/modules/elasticsearch/locals.tf
+++ b/modules/elasticsearch/locals.tf
@@ -2,9 +2,10 @@
 locals {
 
   // Disk
-  disk_type = "pd-ssd"
-  disk_mode = "READ_WRITE"
-  disk_size = 50
+  elastic_search_disk = "${var.project_id}/${var.vm_elastic_search_disk_name}"
+  disk_type           = "pd-ssd"
+  disk_mode           = "READ_WRITE"
+  disk_size           = 50
   // name used to find disk in running image
   disk_mount_name = "es-disk"
   // Ports

--- a/modules/elasticsearch/scripts/instance_startup.sh
+++ b/modules/elasticsearch/scripts/instance_startup.sh
@@ -1,30 +1,37 @@
 #!/bin/bash
 # Startup script for Elastic Search VM Instance
 
-echo "---> [LAUNCH] Open Targets Genetics Portal Elastic Search"
-# In the case of this platform, we don't use Docker for launching ES services.
+echo "---> [LAUNCH] Open Targets Platform Elastic Search"
+
+echo "Prepare ES disk mount"
+es_mount="/mnt/disks"
+es_data="$es_mount/elasticsearch"
+
+sudo mount -o discard,defaults /dev/disk/by-id/google-${ES_DEVICE_ID} $es_mount
+echo "Mount status exit code: $?"
 # Get machine available memory
-#export MACHINE_SIZE=`cat /proc/meminfo | grep MemTotal | grep -o '[0-9]\+'`
+export MACHINE_SIZE=$(cat /proc/meminfo | grep MemTotal | grep -o '[0-9]\+')
 # Set half the available RAM for the JVM
-#export JVM_SIZE=`expr $MACHINE_SIZE / 2097152`
+export JVM_SIZE=$(expr $MACHINE_SIZE / 2097152)
 # Make sure the image is not in use
-#docker stop elasticsearch
-#docker rm elasticsearch
+docker stop elasticsearch
+docker rm elasticsearch
+
+echo "Launching Elasticsearch Docker image"
 # Launch Elastic Search
-#docker run -d \
-#  --name elasticsearch \
-#  --log-driver=gcplogs \
-#  -p 9200:9200 \
-#  -p 9300:9300 \
-#  -e discovery.type=single-node \
-#  -e bootstrap.memory_lock=true \
-#  -e repositories.url.allowed_urls='https://storage.googleapis.com/*,https://*.amazonaws.com/*' \
-#  -e thread_pool.write.queue_size=1000 \
-#  -e cluster.name=`hostname` \
-#  -e network.host=0.0.0.0 \
-#  -e search.max_open_scroll_context=5000 \
-#  -e ES_JAVA_OPTS="-Xms$${JVM_SIZE}g -Xmx$${JVM_SIZE}g" \
-#  -v esdata:/usr/share/elasticsearch/data \
-#  -v /var/elasticsearch/cred:/usr/share/elasticsearch/cred \
-#  -v /var/elasticsearch/log:/var/log/elasticsearch \
-#  docker.elastic.co/elasticsearch/elasticsearch-oss:${ELASTIC_SEARCH_VERSION}
+docker run -d \
+    --name elasticsearch \
+    --log-driver=gcplogs \
+    -p 9200:9200 \
+    -p 9300:9300 \
+    -e discovery.type=single-node \
+    -e bootstrap.memory_lock=true \
+    -e repositories.url.allowed_urls='https://storage.googleapis.com/*,https://*.amazonaws.com/*' \
+    -e thread_pool.write.queue_size=1000 \
+    -e cluster.name=$(hostname) \
+    -e network.host=0.0.0.0 \
+    -e search.max_open_scroll_context=5000 \
+    -e ES_JAVA_OPTS="-Xms$${JVM_SIZE}g -Xmx$${JVM_SIZE}g" \
+    -v $es_data:/usr/share/elasticsearch/data \
+    -v /var/elasticsearch/log:/var/log/elasticsearch \
+    docker.elastic.co/elasticsearch/elasticsearch-oss:${ELASTIC_SEARCH_VERSION}

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -2,37 +2,37 @@
 // General deployment input parameters --- //
 variable "module_wide_prefix_scope" {
   description = "The prefix provided here will scope names for those resources created by this module, default 'mbdevgenesch'"
-  type = string
-  default = "mbdevgenesch"
+  type        = string
+  default     = "mbdevgenesch"
 }
 
 variable "project_id" {
   description = "Project ID where resources will be deployed"
-  type = string
+  type        = string
 }
 
 variable "network_name" {
   description = "Name of the network where resources should be deployed, 'default'"
-  type = string
-  default = "default"
+  type        = string
+  default     = "default"
 }
 
 variable "network_self_link" {
   description = "Self link to the network where resources should be connected when deployed"
-  type = string
-  default = "default"
+  type        = string
+  default     = "default"
 }
 
 variable "network_subnet_name" {
   description = "Name of the subnet, within the 'network_name', and the given region, where instances should be connected to"
-  type = string
-  default = "main-subnet"
+  type        = string
+  default     = "main-subnet"
 }
 
 variable "network_source_ranges" {
   description = "CIDR that represents which IPs we want to grant access to the deployed resources, default '10.0.0.0/9'"
-  type = list(string)
-  default = [ "10.0.0.0/9" ]
+  type        = list(string)
+  default     = ["10.0.0.0/9"]
 }
 
 variable "network_sources_health_checks" {
@@ -45,56 +45,71 @@ variable "network_sources_health_checks" {
 
 variable "deployment_region" {
   description = "Region where resources should be deployed"
-  type = string
+  type        = string
 }
 
 // --- Elastic Search Instance configuration --- //
 variable "deployment_target_size" {
   description = "Initial Elastic Search node count to deploy, default is '1'"
-  type = number
-  default = 1
+  type        = number
+  default     = 1
 }
 
 variable "vm_firewall_tags" {
   description = "Additional tags that should be attached to any Elastic Search Node deployed by this module"
-  type = list(string)
-  default = [ ]
+  type        = list(string)
+  default     = []
 }
 
 variable "vm_elastic_search_version" {
   description = "Elastic Search Docker Image version to use"
-  type = string
+  type        = string
 }
 
 variable "vm_elastic_search_vcpus" {
   description = "CPU count for each Elastic Search Node VM"
-  type = number
+  type        = number
 }
 
 variable "vm_elastic_search_mem" {
   description = "Amount of memory assigned to every Elastic Search Instance (MiB)"
-  type = number
+  type        = number
 }
 
 variable "vm_elastic_search_image" {
   description = "VM Image to use for Elastic Search instances"
-  type = string
+  type        = string
+  default     = "cos-stable"
 }
 
 variable "vm_elastic_search_image_project" {
   description = "Project hosting the Elastic Search VM Instance image"
-  type = string
+  type        = string
+}
+variable "vm_elastic_search_container_project" {
+  description = "Project hosting the Elastic Search VM Instance image"
+  type        = string
+  default     = "cos-cloud"
+}
+variable "vm_elastic_search_boot_disk_size" {
+  description = "Elasticsearch instances boot disk size, default '500GB'"
+  type        = string
+  default     = "500GB"
+}
+variable "vm_elastic_search_disk_project" {
+  description = "Project hosting snapshot created by GOS"
+  type        = string
+}
+variable "vm_elastic_search_disk_name" {
+  description = "Elasticsearch disk snapshot created by GOS"
+  type        = string
+  default     = "es-disk"
 }
 
-variable "vm_elastic_search_boot_disk_size" {
-  description = "Elastic Search instances boot disk size, default '500GB'"
-  type = string
-  default = "500GB"
-}
 
 variable "vm_flag_preemptible" {
   description = "Use this flag to tell the module to use a preemptible instance, default: 'false'"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 

--- a/networking-glb.tf
+++ b/networking-glb.tf
@@ -161,9 +161,9 @@ module "glb" {
         unhealthy_threshold = null
         request_path        = "/admin/health"
         //request_path = "/_ah/health"
-        port         = module.backend_api.api_port
-        host         = null
-        logging      = null
+        port    = module.backend_api.api_port
+        host    = null
+        logging = null
       }
 
       log_config = {

--- a/profiles/deployment_context.devgen
+++ b/profiles/deployment_context.devgen
@@ -23,7 +23,7 @@ config_vm_elastic_search_image          = "cos-stable"
 config_vm_elastic_search_vcpus          = "4"
 config_vm_elastic_search_mem            = "26624"
 config_vm_elastic_search_version        = "7.10.2"
-config_vm_elastic_search_boot_disk_size = "250GB"
+config_vm_elastic_search_boot_disk_size = "10GB"
 config_vm_elastic_search_disk_project = "open-targets-genetics-dev"
 config_vm_elastic_search_disk_name = "snap-es-disk-1w93uzio"
 // --- Clickhouse configuration        --- //
@@ -37,7 +37,7 @@ config_vm_clickhouse_disk_project = "open-targets-genetics-dev"
 config_vm_clickhouse_disk_name = "snap-ch-disk-1w93uzio"
 
 // --- API configuration               --- //
-config_vm_api_image_version  = "22.08.2"
+config_vm_api_image_version  = "22.09.0"
 config_vm_api_image          = "cos-stable"
 config_vm_api_image_project  = "cos-cloud"
 config_vm_api_vcpus          = "2"

--- a/profiles/deployment_context.devgen
+++ b/profiles/deployment_context.devgen
@@ -26,10 +26,13 @@ config_vm_elastic_search_boot_disk_size = "250GB"
 
 // --- Clickhouse configuration        --- //
 config_vm_clickhouse_image_project  = "open-targets-genetics-dev"
-config_vm_clickhouse_image          = "clickhouse-genetics-image-22081508"
+config_vm_clickhouse_container_project = "cos-cloud"
+config_vm_clickhouse_image          = "cos-stable"
 config_vm_clickhouse_vcpus          = "8"
 config_vm_clickhouse_mem            = "53248"
-config_vm_clickhouse_boot_disk_size = "750GB"
+config_vm_clickhouse_boot_disk_size = "50GB"
+config_vm_clickhouse_disk_project = "open-targets-genetics-dev"
+config_vm_clickhouse_disk_name = "snap-ch-disk-1w93uzio"
 
 // --- API configuration               --- //
 config_vm_api_image_version  = "22.08.2"

--- a/profiles/deployment_context.devgen
+++ b/profiles/deployment_context.devgen
@@ -25,7 +25,7 @@ config_vm_elastic_search_mem            = "26624"
 config_vm_elastic_search_version        = "7.10.2"
 config_vm_elastic_search_boot_disk_size = "10GB"
 config_vm_elastic_search_disk_project = "open-targets-genetics-dev"
-config_vm_elastic_search_disk_name = "snap-es-disk-1w93uzio"
+config_vm_elastic_search_disk_name = "es-disk-114jsnbs-image"
 // --- Clickhouse configuration        --- //
 config_vm_clickhouse_image_project  = "open-targets-genetics-dev"
 config_vm_clickhouse_container_project = "cos-cloud"
@@ -34,7 +34,7 @@ config_vm_clickhouse_vcpus          = "8"
 config_vm_clickhouse_mem            = "53248"
 config_vm_clickhouse_boot_disk_size = "50GB"
 config_vm_clickhouse_disk_project = "open-targets-genetics-dev"
-config_vm_clickhouse_disk_name = "snap-ch-disk-1w93uzio"
+config_vm_clickhouse_disk_name = "ch-disk-114jsnbs-image"
 
 // --- API configuration               --- //
 config_vm_api_image_version  = "22.09.0"

--- a/profiles/deployment_context.devgen
+++ b/profiles/deployment_context.devgen
@@ -18,12 +18,14 @@ config_dns_api_subdomain         = "api"
 
 // --- Elastic Search configuration    --- //
 config_vm_elastic_search_image_project  = "open-targets-genetics-dev"
-config_vm_elastic_search_image          = "elasticsearch-genetics-image-22081208"
+config_vm_elastic_search_container_project = "cos-cloud"
+config_vm_elastic_search_image          = "cos-stable"
 config_vm_elastic_search_vcpus          = "4"
 config_vm_elastic_search_mem            = "26624"
-config_vm_elastic_search_version        = "7.9.0"
+config_vm_elastic_search_version        = "7.10.2"
 config_vm_elastic_search_boot_disk_size = "250GB"
-
+config_vm_elastic_search_disk_project = "open-targets-genetics-dev"
+config_vm_elastic_search_disk_name = "snap-es-disk-1w93uzio"
 // --- Clickhouse configuration        --- //
 config_vm_clickhouse_image_project  = "open-targets-genetics-dev"
 config_vm_clickhouse_container_project = "cos-cloud"

--- a/variables.tf
+++ b/variables.tf
@@ -149,12 +149,25 @@ variable "config_vm_clickhouse_disk_project" {
   description = "Project hosting disk snapshots to deploy"
   type        = string
 }
+variable "config_vm_elastic_search_container_project" {
+  description = "Project hosting container optimised machine images to deploy"
+  type        = string
+}
+
 
 variable "config_vm_clickhouse_disk_name" {
   description = "Disk snapshot for Clickhouse data."
   type        = string
 }
+variable "config_vm_elastic_search_disk_project" {
+  description = "Project hosting disk snapshots to deploy"
+  type        = string
+}
 
+variable "config_vm_elastic_search_disk_name" {
+  description = "Disk snapshot for elastic_search data."
+  type        = string
+}
 variable "config_vm_clickhouse_image_project" {
   description = "Project where to find the instance image to use"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,21 @@ variable "config_vm_clickhouse_image" {
   type        = string
 }
 
+variable "config_vm_clickhouse_container_project" {
+  description = "Project hosting container optimised machine images to deploy"
+  type        = string
+}
+
+variable "config_vm_clickhouse_disk_project" {
+  description = "Project hosting disk snapshots to deploy"
+  type        = string
+}
+
+variable "config_vm_clickhouse_disk_name" {
+  description = "Disk snapshot for Clickhouse data."
+  type        = string
+}
+
 variable "config_vm_clickhouse_image_project" {
   description = "Project where to find the instance image to use"
   type        = string


### PR DESCRIPTION
- Update Clickhouse to be deployed from disk snapshot
- Update formatting with `terraform fmt`
- Update devgen deployment context for CH
- Add CH defaults for docker optimised machine image.
- Update ES to be deployed from disk snapshot.
- Simplify mount path for CH disk in image.
- Update API version to 22.09.0
- Updating snapshot location specification for es and ch modules.
- Update CH and ES to use disk images
- Update device names in ES and CH
