### PR TITLE
Bug fix secondary disk image location for CH and ES

### DIFF
--- a/modules/clickhouse/locals.tf
+++ b/modules/clickhouse/locals.tf
@@ -2,7 +2,7 @@
 locals {
 
   // Disk
-  clickhouse_disk = "${var.project_id}/${var.vm_clickhouse_disk_name}"
+  clickhouse_disk = "${var.vm_clickhouse_disk_project}/${var.vm_clickhouse_disk_name}"
   disk_type       = "pd-ssd"
   disk_mode       = "READ_WRITE"
   disk_size       = 250

--- a/modules/elasticsearch/locals.tf
+++ b/modules/elasticsearch/locals.tf
@@ -2,7 +2,7 @@
 locals {
 
   // Disk
-  elastic_search_disk = "${var.project_id}/${var.vm_elastic_search_disk_name}"
+  elastic_search_disk = "${var.vm_elastic_search_disk_project}/${var.vm_elastic_search_disk_name}"
   disk_type           = "pd-ssd"
   disk_mode           = "READ_WRITE"
   disk_size           = 50


### PR DESCRIPTION
This PR fixes a bug in the infrastructure definition related to the location of the data backend images (ES and CH).